### PR TITLE
Change Uncompress() to return size

### DIFF
--- a/header.go
+++ b/header.go
@@ -40,7 +40,8 @@ func CompressAllocHdr(in []byte) (out []byte, err error) {
 // UncompressHdr uncompresses in into out.  Out must have enough space allocated
 // for the uncompressed message.
 func UncompressHdr(out, in []byte) error {
-	return Uncompress(out, in[4:])
+	_, err := Uncompress(out, in[4:])
+	return err
 }
 
 // UncompressAllocHdr uncompresses the stream from in into out if out has enough

--- a/lz4.go
+++ b/lz4.go
@@ -7,7 +7,6 @@ import "C"
 
 import (
 	"errors"
-	"fmt"
 	"unsafe"
 )
 
@@ -26,12 +25,12 @@ func clen(s []byte) C.int {
 
 // Uncompress with a known output size. len(out) should be equal to
 // the length of the uncompressed out.
-func Uncompress(out, in []byte) error {
-	if int(C.LZ4_decompress_safe(p(in), p(out), clen(in), clen(out))) < 0 {
-		return errors.New("Malformed compression stream")
+func Uncompress(out, in []byte) (outSize int, err error) {
+	outSize = int(C.LZ4_decompress_safe(p(in), p(out), clen(in), clen(out)))
+	if outSize < 0 {
+		err = errors.New("Malformed compression stream")
 	}
-
-	return nil
+	return
 }
 
 // CompressBound calculates the size of the output buffer needed by
@@ -49,7 +48,7 @@ func CompressBound(in []byte) int {
 func Compress(out, in []byte) (outSize int, err error) {
 	outSize = int(C.LZ4_compress_limitedOutput(p(in), p(out), clen(in), clen(out)))
 	if outSize == 0 {
-		err = fmt.Errorf("insufficient space for compression")
+		err = errors.New("Insufficient space for compression")
 	}
 	return
 }

--- a/lz4_hc_test.go
+++ b/lz4_hc_test.go
@@ -83,7 +83,7 @@ func TestCompressionHC(t *testing.T) {
 	}
 	output = output[:outSize]
 	decompressed := make([]byte, len(input))
-	err = Uncompress(decompressed, output)
+	_, err = Uncompress(decompressed, output)
 	if err != nil {
 		t.Fatalf("Decompression failed: %v", err)
 	}
@@ -105,7 +105,7 @@ func TestEmptyCompressionHC(t *testing.T) {
 	}
 	output = output[:outSize]
 	decompressed := make([]byte, len(input))
-	err = Uncompress(decompressed, output)
+	_, err = Uncompress(decompressed, output)
 	if err != nil {
 		t.Fatalf("Decompression failed: %v", err)
 	}
@@ -126,7 +126,7 @@ func TestNoCompressionHC(t *testing.T) {
 	}
 	output = output[:outSize]
 	decompressed := make([]byte, len(input))
-	err = Uncompress(decompressed, output)
+	_, err = Uncompress(decompressed, output)
 	if err != nil {
 		t.Fatalf("Decompression failed: %v", err)
 	}
@@ -167,19 +167,19 @@ func TestDecompressionErrorHC(t *testing.T) {
 	}
 	output = output[:outSize]
 	decompressed := make([]byte, len(input)-1)
-	err = Uncompress(decompressed, output)
+	_, err = Uncompress(decompressed, output)
 	if err == nil {
 		t.Fatalf("Decompression should have failed")
 	}
 
 	decompressed = make([]byte, 1)
-	err = Uncompress(decompressed, output)
+	_, err = Uncompress(decompressed, output)
 	if err == nil {
 		t.Fatalf("Decompression should have failed")
 	}
 
 	decompressed = make([]byte, 0)
-	err = Uncompress(decompressed, output)
+	_, err = Uncompress(decompressed, output)
 	if err == nil {
 		t.Fatalf("Decompression should have failed")
 	}
@@ -197,7 +197,7 @@ func TestFuzzHC(t *testing.T) {
 		}
 		output = output[:outSize]
 		decompressed := make([]byte, len(input))
-		err = Uncompress(decompressed, output)
+		_, err = Uncompress(decompressed, output)
 		if err != nil {
 			t.Fatalf("Decompression failed: %v", err)
 		}

--- a/lz4_test.go
+++ b/lz4_test.go
@@ -42,7 +42,7 @@ func TestCompression(t *testing.T) {
 	}
 	output = output[:outSize]
 	decompressed := make([]byte, len(input))
-	err = Uncompress(decompressed, output)
+	_, err = Uncompress(decompressed, output)
 	if err != nil {
 		t.Fatalf("Decompression failed: %v", err)
 	}
@@ -63,7 +63,7 @@ func TestEmptyCompression(t *testing.T) {
 	}
 	output = output[:outSize]
 	decompressed := make([]byte, len(input))
-	err = Uncompress(decompressed, output)
+	_, err = Uncompress(decompressed, output)
 	if err != nil {
 		t.Fatalf("Decompression failed: %v", err)
 	}
@@ -84,7 +84,7 @@ func TestNoCompression(t *testing.T) {
 	}
 	output = output[:outSize]
 	decompressed := make([]byte, len(input))
-	err = Uncompress(decompressed, output)
+	_, err = Uncompress(decompressed, output)
 	if err != nil {
 		t.Fatalf("Decompression failed: %v", err)
 	}
@@ -120,19 +120,19 @@ func TestDecompressionError(t *testing.T) {
 	}
 	output = output[:outSize]
 	decompressed := make([]byte, len(input)-1)
-	err = Uncompress(decompressed, output)
+	_, err = Uncompress(decompressed, output)
 	if err == nil {
 		t.Fatalf("Decompression should have failed")
 	}
 
 	decompressed = make([]byte, 1)
-	err = Uncompress(decompressed, output)
+	_, err = Uncompress(decompressed, output)
 	if err == nil {
 		t.Fatalf("Decompression should have failed")
 	}
 
 	decompressed = make([]byte, 0)
-	err = Uncompress(decompressed, output)
+	_, err = Uncompress(decompressed, output)
 	if err == nil {
 		t.Fatalf("Decompression should have failed")
 	}
@@ -173,7 +173,7 @@ func TestFuzz(t *testing.T) {
 		}
 		output = output[:outSize]
 		decompressed := make([]byte, len(input))
-		err = Uncompress(decompressed, output)
+		_, err = Uncompress(decompressed, output)
 		if err != nil {
 			t.Fatalf("Decompression failed: %v", err)
 		}


### PR DESCRIPTION
Similar to Compress(), change Uncompress() return type  to (outsize int, err error). It's sometimes useful to have access to the size of the decompressed data.