### PR TITLE
Stop using deprecated functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # golz4 CHANGELOG
 
+## v1.0.1
+
+Do not use deprecated LZ4 functions anymore. This removes the warnings that show up during compilation. The API or its behavior remains unchanged.
+
 ## v1.0.0
 
 While this release **does not break API compatibility**, it changes the way the library is built.

--- a/lz4.go
+++ b/lz4.go
@@ -54,7 +54,7 @@ func CompressBound(in []byte) int {
 // should have enough space for the compressed data (use CompressBound
 // to calculate). Returns the number of bytes in the out slice.
 func Compress(out, in []byte) (outSize int, err error) {
-	outSize = int(C.LZ4_compress_limitedOutput(p(in), p(out), clen(in), clen(out)))
+	outSize = int(C.LZ4_compress_default(p(in), p(out), clen(in), clen(out)))
 	if outSize == 0 {
 		err = errors.New("Insufficient space for compression")
 	}

--- a/lz4_hc.go
+++ b/lz4_hc.go
@@ -29,7 +29,7 @@ func CompressHCLevel(out, in []byte, level int) (outSize int, err error) {
 		return Compress(out, in)
 	}
 
-	outSize = int(C.LZ4_compressHC2_limitedOutput(p(in), p(out), clen(in), clen(out), C.int(level)))
+	outSize = int(C.LZ4_compress_HC(p(in), p(out), clen(in), clen(out), C.int(level)))
 	if outSize == 0 {
 		err = fmt.Errorf("insufficient space for compression")
 	}


### PR DESCRIPTION
This is a noop
* `LZ4_compress_limitedOutput` calls `LZ4_compress_default`: https://github.com/lz4/lz4/blob/v1.9.2/lib/lz4.c#L2335-L2338
* `LZ4_compressHC2_limitedOutput` calls `LZ4_compress_HC`: https://github.com/lz4/lz4/blob/v1.9.2/lib/lz4hc.c#L1156