### PR TITLE
Fix reader out of bounds

### DIFF
--- a/lz4.go
+++ b/lz4.go
@@ -14,8 +14,8 @@ import (
 )
 
 const (
-	streamingBlockSize       = 1024 * 64
-	boudedStreamingBlockSize = streamingBlockSize + streamingBlockSize/255 + 16
+	streamingBlockSize        = 1024 * 64
+	boundedStreamingBlockSize = streamingBlockSize + streamingBlockSize/255 + 16
 )
 
 // p gets a char pointer to the first byte of a []byte slice
@@ -94,7 +94,7 @@ func (w *Writer) Write(src []byte) (int, error) {
 
 	inpPtr := w.compressionBuffer[w.inpBufIndex]
 
-	var compressedBuf [boudedStreamingBlockSize]byte
+	var compressedBuf [boundedStreamingBlockSize]byte
 	copy(inpPtr[:], src)
 
 	written := int(C.LZ4_compress_fast_continue(
@@ -158,8 +158,8 @@ func NewReader(r io.Reader) io.ReadCloser {
 		isLeft:           true,
 		// double buffer needs to use C.malloc to make sure the same memory address
 		// allocate buffers in go memory will fail randomly since GC may move the memory
-		left:  C.malloc(boudedStreamingBlockSize),
-		right: C.malloc(boudedStreamingBlockSize),
+		left:  C.malloc(boundedStreamingBlockSize),
+		right: C.malloc(boundedStreamingBlockSize),
 	}
 }
 
@@ -189,7 +189,7 @@ func (r *reader) Read(dst []byte) (int, error) {
 	}
 
 	// read blockSize from r.underlyingReader --> readBuffer
-	var uncompressedBuf [boudedStreamingBlockSize]byte
+	var uncompressedBuf [boundedStreamingBlockSize]byte
 	_, err = io.ReadFull(r.underlyingReader, uncompressedBuf[:blockSize])
 	if err != nil {
 		return 0, err

--- a/lz4.go
+++ b/lz4.go
@@ -156,6 +156,12 @@ func NewReader(r io.Reader) io.ReadCloser {
 		lz4Stream:        C.LZ4_createStreamDecode(),
 		underlyingReader: r,
 		isLeft:           true,
+		// As per lz4 docs:
+		//
+		//   *_continue() :
+		//     These decoding functions allow decompression of multiple blocks in "streaming" mode.
+		//     Previously decoded blocks must still be available at the memory position where they were decoded.
+		//
 		// double buffer needs to use C.malloc to make sure the same memory address
 		// allocate buffers in go memory will fail randomly since GC may move the memory
 		left:  C.malloc(boundedStreamingBlockSize),

--- a/lz4_test.go
+++ b/lz4_test.go
@@ -212,8 +212,9 @@ func TestFuzz(t *testing.T) {
 
 func TestSimpleCompressDecompress(t *testing.T) {
 	data := bytes.NewBuffer(nil)
-	for i := 0; i < 20; i++ {
-		data.WriteString(fmt.Sprintf("%02d-abcdefghijklmnopqrstuvwxyz ", i))
+	// NOTE: make the buffer bigger than 65k to cover all use cases
+	for i := 0; i < 2000; i++ {
+		data.WriteString(fmt.Sprintf("%04d-abcdefghijklmnopqrstuvwxyz ", i))
 	}
 	w := bytes.NewBuffer(nil)
 	wc := NewWriter(w)

--- a/lz4_test.go
+++ b/lz4_test.go
@@ -8,6 +8,7 @@ package lz4
 import (
 	"bytes"
 	"crypto/rand"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -210,11 +211,14 @@ func TestFuzz(t *testing.T) {
 }
 
 func TestSimpleCompressDecompress(t *testing.T) {
-	data := []byte("this\nis\njust\na\ntestttttttttt.")
+	data := bytes.NewBuffer(nil)
+	for i := 0; i < 20; i++ {
+		data.WriteString(fmt.Sprintf("%02d-abcdefghijklmnopqrstuvwxyz ", i))
+	}
 	w := bytes.NewBuffer(nil)
 	wc := NewWriter(w)
 	defer wc.Close()
-	_, err := wc.Write(data)
+	_, err := wc.Write(data.Bytes())
 
 	// Decompress
 	bufOut := bytes.NewBuffer(nil)
@@ -222,7 +226,7 @@ func TestSimpleCompressDecompress(t *testing.T) {
 	_, err = io.Copy(bufOut, r)
 	failOnError(t, "Failed writing to file", err)
 
-	if bufOut.String() != string(data) {
+	if bufOut.String() != data.String() {
 		t.Fatalf("Decompressed output != input: %q != %q", bufOut.String(), data)
 	}
 }


### PR DESCRIPTION
The first commit illustrates the issue (see CI: https://circleci.com/gh/DataDog/golz4/36).

When decompressing data, size of `dst` was not checked and the slice taken for writing turns into an out of bound panic.

The fix relies on a separate buffer to hold the decompressed bytes that cannot be written right away.
The implementation is fairly straightforward: on Read() either consume from the internal buffer or decompress more data.