### PR TITLE
Write supports any input size

### DIFF
--- a/lz4_test.go
+++ b/lz4_test.go
@@ -213,13 +213,16 @@ func TestFuzz(t *testing.T) {
 func TestSimpleCompressDecompress(t *testing.T) {
 	data := bytes.NewBuffer(nil)
 	// NOTE: make the buffer bigger than 65k to cover all use cases
-	for i := 0; i < 2000; i++ {
+	for i := 0; i < 3000; i++ {
 		data.WriteString(fmt.Sprintf("%04d-abcdefghijklmnopqrstuvwxyz ", i))
 	}
 	w := bytes.NewBuffer(nil)
 	wc := NewWriter(w)
 	defer wc.Close()
 	_, err := wc.Write(data.Bytes())
+	if err != nil {
+		t.Fatalf("Compression of %d bytes of data failed: %s", len(data.Bytes()), err)
+	}
 
 	// Decompress
 	bufOut := bytes.NewBuffer(nil)


### PR DESCRIPTION
Previous implementation failed writes if the data buffer to compress was bigger than 65 KB.

Sadly, when chaining streams, the user does not always control the size of the buffers provided to the LZ4 Writer, failing the whole write pipeline.

This implementation supports any size for the input buffer, consuming the data by at most 65 KB of data.

The patch implies that providing an empty buffer to the Write function *will not* write a header with 0 size. This is why the `Read` function had to be patched to check for `dst` emptyness.