### PR TITLE
Write buffers do not move in memory

### DIFF
--- a/lz4_test.go
+++ b/lz4_test.go
@@ -213,13 +213,16 @@ func TestFuzz(t *testing.T) {
 func TestSimpleCompressDecompress(t *testing.T) {
 	data := bytes.NewBuffer(nil)
 	// NOTE: make the buffer bigger than 65k to cover all use cases
-	for i := 0; i < 2000; i++ {
+	for i := 0; i < 3000; i++ {
 		data.WriteString(fmt.Sprintf("%04d-abcdefghijklmnopqrstuvwxyz ", i))
 	}
 	w := bytes.NewBuffer(nil)
 	wc := NewWriter(w)
 	defer wc.Close()
 	_, err := wc.Write(data.Bytes())
+	if err != nil {
+		t.Fatalf("Compression of %d bytes of data failed: %s", len(data.Bytes()), err)
+	}
 
 	// Decompress
 	bufOut := bytes.NewBuffer(nil)


### PR DESCRIPTION
The `LZ4_compress_fast_continue` documentation is clear about this: any input data passed to the previous call, should still be available at the same memory address.

Using Go byte arrays, managed by the GC did not fulfil that requirement because the arrays can be moved around in memory between two consecutive calls to the write function.

This PR depends on #10 and only the last commit is relevant.