### PR TITLE
Refactor stream reads

### DIFF
--- a/double_buffer.go
+++ b/double_buffer.go
@@ -1,0 +1,60 @@
+package lz4
+
+// #include <stdlib.h>
+import "C"
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+// doubleBuffer provides a C malloc'd double buffer.
+//
+// The reason this is needed is because the streaming API of the lz4 C library
+// relies on buffer content from the previous call and this content needs to be
+// located at the exact same address in memory.
+type doubleBuffer struct {
+	bufferSize int
+	buffers    [2]unsafe.Pointer
+	current    int
+}
+
+// newDoubleBuffer creates double buffer, each of the given size in bytes
+//
+// Unused doubleBuffer need to be released using Free() to avoid memory leaks
+func newDoubleBuffer(sizeBytes int) *doubleBuffer {
+	return &doubleBuffer{
+		bufferSize: sizeBytes,
+		buffers: [2]unsafe.Pointer{
+			C.malloc(C.ulong(sizeBytes)),
+			C.malloc(C.ulong(sizeBytes)),
+		},
+		current: 0,
+	}
+}
+
+// Free the internal buffers.
+//
+// Once this method has been called, the doubleBuffer CANNOT be used anymore
+func (b *doubleBuffer) Free() {
+	C.free(b.buffers[0])
+	b.buffers[0] = nil
+	C.free(b.buffers[1])
+	b.buffers[1] = nil
+
+	b.bufferSize = 0
+	b.current = 0
+}
+
+// NextBuffer pulls a buffer, in a round-robin fashion
+func (b *doubleBuffer) NextBuffer() []byte {
+	ptr := b.buffers[b.current]
+	tmpSlice := reflect.SliceHeader{
+		Data: uintptr(ptr),
+		Len:  b.bufferSize,
+		Cap:  b.bufferSize,
+	}
+	byteSlice := *(*[]byte)(unsafe.Pointer(&tmpSlice))
+	b.current = (b.current + 1) % 2
+	return byteSlice
+}


### PR DESCRIPTION
This PR refactors how data is read and uncompressed.

It adds a `doubleBuffer` helper struct to do the magic C, double buffer dance and makes use of this in the `Read` function.

Here are the benchmarks comparing the current `master` with this branch:

#### master

```
$ go test -bench='^BenchmarkStreamUncompress.*' -benchtime 15s -count 2
goos: darwin
goarch: amd64
pkg: github.com/DataDog/golz4
BenchmarkStreamUncompress-4   	 5527802	      4236 ns/op	7735.24 MB/s	     123 B/op	       2 allocs/op
BenchmarkStreamUncompress-4   	 3750264	      6997 ns/op	4682.91 MB/s	     142 B/op	       2 allocs/op
PASS
ok  	github.com/DataDog/golz4	65.629s
```

#### New version

```
$ go test -bench='^BenchmarkStreamUncompress.*' -benchtime 15s -count 2
goos: darwin
goarch: amd64
pkg: github.com/DataDog/golz4
BenchmarkStreamUncompress-4   	 5643277	      4133 ns/op	7927.65 MB/s	     126 B/op	       3 allocs/op
BenchmarkStreamUncompress-4   	 3755970	      6837 ns/op	4792.58 MB/s	     140 B/op	       3 allocs/op
PASS
ok  	github.com/DataDog/golz4	65.232s
```

Performance is very similar, sometimes a bit better. There's still an extra alloc that slipped through the cracks, probably related to the addition of `doubleBuffer`.

FWIW, I also tested moving the  temporary `readBuffer` as a struct member but this turned out to be worse, performance wise