### PR TITLE
Uncompress(Alloc)Hdr: Return an error if input it too short

### DIFF
--- a/header_test.go
+++ b/header_test.go
@@ -76,6 +76,31 @@ func TestEmptyCompressionHdr(t *testing.T) {
 	}
 }
 
+func TestUncompressHdrShort(t *testing.T) {
+	// calling Uncompress(Alloc)Hdr with input that is too short should return an error, not panic
+	output := make([]byte, 1)
+	for i := 0; i < 4; i++ {
+		tooShortInput := make([]byte, i)
+		out2, err := UncompressAllocHdr(output, tooShortInput)
+		if err != errTooShort {
+			t.Errorf("UncompressAllocHdr(output, [%d zero bytes]) returned unexpected err=%v",
+				len(tooShortInput), err)
+		}
+		// UncompressAllocHdr should always returns its first argument
+		// sadly slice identity is hard; cheat with Sprintf("%p")
+		if fmt.Sprintf("%p", out2) != fmt.Sprintf("%p", output) {
+			t.Errorf("UncompressAllocHdr([%p], [%d zero bytes]) returned output=%p",
+				output, len(tooShortInput), out2)
+		}
+
+		err = UncompressHdr(output, tooShortInput)
+		if err != errTooShort {
+			t.Errorf("UncompressHdr(output, [%d zero bytes]) returned unexpected err=%v",
+				len(tooShortInput), err)
+		}
+	}
+}
+
 // test python interoperability
 
 // pymod returns whether or not a python module is importable.  For checking


### PR DESCRIPTION
Previously these functions would panic on bad input, unlike liblz4
itself, which returns errors if the input is bad. This will ensure
callers can handle errors if the input is bad, rather than crash.
Since decompression functions are typically used with input
from outside a program, this seems worth the cost of an extra
bounds check.

A brief audit of a code base which uses these functions shows that
many calls have no check. Some check for nil or len(input) == 0,
which is incomplete.