### PR TITLE
lz4.go: Fix Go 1.16 SliceHeader vet warnings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/DataDog/golz4
 
-go 1.13
+go 1.17

--- a/lz4.go
+++ b/lz4.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"reflect"
 	"unsafe"
 )
 
@@ -153,13 +152,7 @@ func (w *Writer) writeFrame(src []byte) (int, error) {
 }
 
 func (w *Writer) nextInputBuffer() []byte {
-	w.inpBufIndex = (w.inpBufIndex + 1) % 2
-	var result []byte
-	resultHeader := (*reflect.SliceHeader)(unsafe.Pointer(&result))
-	resultHeader.Data = uintptr(w.compressionBuffer[w.inpBufIndex])
-	resultHeader.Len = streamingBlockSize
-	resultHeader.Cap = streamingBlockSize
-	return result
+	return unsafe.Slice((*byte)(w.compressionBuffer[w.inpBufIndex]), streamingBlockSize)
 }
 
 // Close releases all the resources occupied by Writer.
@@ -501,10 +494,5 @@ func (r *DecompressReader) readSize(rdr io.Reader) (int, error) {
 }
 
 func ptrToByteSlice(dataPtr unsafe.Pointer, _len, _cap int) []byte {
-	var result []byte
-	resultHeader := (*reflect.SliceHeader)(unsafe.Pointer(&result))
-	resultHeader.Data = uintptr(dataPtr)
-	resultHeader.Len = _len
-	resultHeader.Cap = _cap
-	return result
+	return unsafe.Slice((*byte)(dataPtr), _len)
 }

--- a/lz4.go
+++ b/lz4.go
@@ -154,12 +154,12 @@ func (w *Writer) writeFrame(src []byte) (int, error) {
 
 func (w *Writer) nextInputBuffer() []byte {
 	w.inpBufIndex = (w.inpBufIndex + 1) % 2
-	tmpSlice := reflect.SliceHeader{
-		Data: uintptr(w.compressionBuffer[w.inpBufIndex]),
-		Len:  streamingBlockSize,
-		Cap:  streamingBlockSize,
-	}
-	return *(*[]byte)(unsafe.Pointer(&tmpSlice))
+	var result []byte
+	resultHeader := (*reflect.SliceHeader)(unsafe.Pointer(&result))
+	resultHeader.Data = uintptr(w.compressionBuffer[w.inpBufIndex])
+	resultHeader.Len = streamingBlockSize
+	resultHeader.Cap = streamingBlockSize
+	return result
 }
 
 // Close releases all the resources occupied by Writer.
@@ -501,10 +501,10 @@ func (r *DecompressReader) readSize(rdr io.Reader) (int, error) {
 }
 
 func ptrToByteSlice(dataPtr unsafe.Pointer, _len, _cap int) []byte {
-	tmpSlice := reflect.SliceHeader{
-		Data: uintptr(dataPtr),
-		Len:  _len,
-		Cap:  _cap,
-	}
-	return *(*[]byte)(unsafe.Pointer(&tmpSlice))
+	var result []byte
+	resultHeader := (*reflect.SliceHeader)(unsafe.Pointer(&result))
+	resultHeader.Data = uintptr(dataPtr)
+	resultHeader.Len = _len
+	resultHeader.Cap = _cap
+	return result
 }


### PR DESCRIPTION
Go 1.16 added vet warnings to check for unsafe uses of
reflect.SliceHeader. To fix them, create an empty slice, then alter
that slice using *reflect.SliceHeader. This is apparently safer
because it works with escape analysis and garbage collection [1].
This pattern is also used in golang.org/x/sys so this should be safe.
For example, see Mmap in syscall_unix.go:

https://cs.opensource.google/go/x/sys/+/master:unix/syscall_unix.go

[1] https://github.com/golang/go/issues/40701

Fixes:

./lz4.go:162:35: possible misuse of reflect.SliceHeader
./lz4.go:509:35: possible misuse of reflect.SliceHeader