### PR TITLE
lz4.go: Mark NewReader deprecated with the Go comment style

### DIFF
--- a/lz4.go
+++ b/lz4.go
@@ -182,7 +182,8 @@ type reader struct {
 // Close on the ReadCloser when done.  If this is not done, underlying objects
 // in the lz4 library will not be freed.
 //
-// Deprecated: Use NewDecompressReader instead.
+// Deprecated: Use NewDecompressReader instead. It can decompress the output
+// of NewWriter, but uses fewer allocations.
 func NewReader(r io.Reader) io.ReadCloser {
 	return &reader{
 		lz4Stream:        C.LZ4_createStreamDecode(),
@@ -309,7 +310,8 @@ type CompressReader struct {
 // NewCompressReader creates a new io.ReadCloser.  Reads from the returned ReadCloser
 // read and compress data from r.  It is the caller's responsibility to call
 // Close on the ReadCloser when done.  If this is not done, underlying objects
-// in the lz4 library will not be freed.
+// in the lz4 library will not be freed. The compressed output must be decompressed
+// using NewDecompressReader.
 func NewCompressReader(r io.Reader) *CompressReader {
 	return &CompressReader{
 		compressionBuffer: [2]unsafe.Pointer{

--- a/lz4.go
+++ b/lz4.go
@@ -177,11 +177,12 @@ type reader struct {
 	isLeft           bool
 }
 
-// DEPRECATED: Use NewDecompressReader instead.
 // NewReader creates a new io.ReadCloser.  Reads from the returned ReadCloser
 // read and decompress data from r.  It is the caller's responsibility to call
 // Close on the ReadCloser when done.  If this is not done, underlying objects
 // in the lz4 library will not be freed.
+//
+// Deprecated: Use NewDecompressReader instead.
 func NewReader(r io.Reader) io.ReadCloser {
 	return &reader{
 		lz4Stream:        C.LZ4_createStreamDecode(),


### PR DESCRIPTION
Go tools like staticcheck can detect that this function is deprecated
if the comment starts on its own in a new paragraph. Change the
comment on NewReader to use this style. See:

https://go.dev/blog/godoc