### PR TITLE
lz4_test.go: Fix/rename BenchmarkStreamUncompress

### DIFF
--- a/lz4_test.go
+++ b/lz4_test.go
@@ -597,13 +597,16 @@ func BenchmarkStreamCompressReader(b *testing.B) {
 	}
 }
 
-func BenchmarkStreamUncompress(b *testing.B) {
+func BenchmarkDeprecatedStreamUncompress(b *testing.B) {
 	var compressedBuffer bytes.Buffer
-	r := NewCompressReader(io.LimitReader(Null, 10*1024*1024))
-	if _, err := io.Copy(&compressedBuffer, r); err != nil {
-		b.Fatalf("Failed writing to compress object: %s", err)
+	w := NewWriter(&compressedBuffer)
+	if _, err := io.Copy(w, io.LimitReader(Null, 10*1024*1024)); err != nil {
+		b.Fatalf("Failed writing to NewWriter: %s", err)
 	}
-	r.Close()
+	err := w.Close()
+	if err != nil {
+		b.Fatal(err)
+	}
 
 	b.ReportAllocs()
 	b.ResetTimer()


### PR DESCRIPTION
This benchmark previously failed to execute. The problem is it used
NewCompressReader to compress data, then tried to decompress it with
NewReader. These functions are not compatible. Fix the benchmark to
use NewWriter() to compress and NewReader() to decompress. Rename
the benchmark to Deprecated, since the NewReader() function is marked
as deprecated.

The NewCompressReader/NewDecompressReader pair are benchmarked in
BenchmarkStreamDecompressReader.