### PR TITLE
NewCompressReader: Separate buffers to LZ4_compress_fast_continue

### DIFF
--- a/lz4.go
+++ b/lz4.go
@@ -102,9 +102,10 @@ func NewWriter(w io.Writer) *Writer {
 
 	// separate the buffers by 8 bytes, so LZ4 treats them as separate. 8 bytes means the buffer
 	// start is 8 byte aligned, which may permit optimizations on 64-bit CPUs.
-	mallocBuffer := C.malloc(2*streamingBlockSize + 8)
+	const bufferSeparation = 8
+	mallocBuffer := C.malloc(2*streamingBlockSize + bufferSeparation)
 	buffer1 := mallocBuffer
-	buffer2 := unsafe.Pointer(uintptr(mallocBuffer) + streamingBlockSize + 8)
+	buffer2 := unsafe.Pointer(uintptr(mallocBuffer) + streamingBlockSize + bufferSeparation)
 
 	return &Writer{
 		compressionBuffer: [2]unsafe.Pointer{buffer1, buffer2},
@@ -321,6 +322,7 @@ func (r *reader) readFromPending(dst []byte) (int, error) {
 type CompressReader struct {
 	underlyingReader       io.Reader
 	compressionBuffer      [2]unsafe.Pointer
+	mallocBuffer           unsafe.Pointer
 	outputBuffer           *bytes.Reader
 	lz4Stream              *C.LZ4_stream_t
 	inpBufIndex            int
@@ -334,15 +336,27 @@ type CompressReader struct {
 // in the lz4 library will not be freed. The compressed output must be decompressed
 // using NewDecompressReader.
 func NewCompressReader(r io.Reader) *CompressReader {
+	// The input buffers MUST NOT be contiguous in memory so the two blocks are treated as separate.
+	// We had a bug in Writer when malloc decided to allocate buffers contiguously. This bug does
+	// not happen with CompressReader, because we only have "partial" blocks at EOF, and we need two
+	// calls to LZ4_compress_fast_continue with sizes < 64 kiB to trigger the problem. However, we
+	// should separate these buffers explicitly, to make this impossible. For details, see the
+	// comment in NewWriter.
+
+	// separate the buffers by 8 bytes, so LZ4 treats them as separate. 8 bytes means the buffer
+	// start is 8 byte aligned, which may permit optimizations on 64-bit CPUs.
+	const bufferSeparation = 8
+	mallocBuffer := C.malloc(2*hugeStreamingBlockSize + bufferSeparation)
+	buffer1 := mallocBuffer
+	buffer2 := unsafe.Pointer(uintptr(mallocBuffer) + hugeStreamingBlockSize + bufferSeparation)
+
 	return &CompressReader{
-		compressionBuffer: [2]unsafe.Pointer{
-			C.malloc(hugeStreamingBlockSize),
-			C.malloc(hugeStreamingBlockSize),
-		},
-		lz4Stream:        C.LZ4_createStream(),
-		underlyingReader: r,
-		outputBuffer:     bytes.NewReader(nil),
-		compressedBuffer: C.malloc(boundedHugeStreamingBlockSize + blockHeaderSize),
+		compressionBuffer: [2]unsafe.Pointer{buffer1, buffer2},
+		mallocBuffer:      mallocBuffer,
+		lz4Stream:         C.LZ4_createStream(),
+		underlyingReader:  r,
+		outputBuffer:      bytes.NewReader(nil),
+		compressedBuffer:  C.malloc(boundedHugeStreamingBlockSize + blockHeaderSize),
 	}
 }
 
@@ -408,10 +422,12 @@ func (r *CompressReader) Close() error {
 	if r.lz4Stream != nil {
 		C.LZ4_freeStream(r.lz4Stream)
 		r.lz4Stream = nil
+		C.free(r.mallocBuffer)
+		r.mallocBuffer = nil
+		C.free(r.compressedBuffer)
+		r.compressedBuffer = nil
 	}
-	C.free(r.compressionBuffer[0])
-	C.free(r.compressionBuffer[1])
-	C.free(r.compressedBuffer)
+
 	return nil
 }
 

--- a/lz4.go
+++ b/lz4.go
@@ -99,8 +99,8 @@ func NewWriter(w io.Writer) *Writer {
 	// with some space between them. However, on Mac OS X, the buffers are often contiguous.
 	// See: https://github.com/lz4/lz4/issues/473#issuecomment-366537441
 
-	// separate the buffers by 8 bytes, so LZ4 treats them as separate. 8 bytes means the buffer
-	// start is 8 byte aligned, which may permit optimizations on 64-bit CPUs.
+	// Separate the buffers so LZ4 treats them as separate. Use 8 bytes to maintain 8 byte alignment,
+	// assuming malloc's result was aligned. This may permit optimizations on 64-bit CPUs.
 	const bufferSeparation = 8
 	mallocBuffer := C.malloc(2*streamingBlockSize + bufferSeparation)
 	buffer1 := mallocBuffer
@@ -340,8 +340,8 @@ func NewCompressReader(r io.Reader) *CompressReader {
 	// should separate these buffers explicitly, to make this impossible. For details, see the
 	// comment in NewWriter.
 
-	// separate the buffers by 8 bytes, so LZ4 treats them as separate. 8 bytes means the buffer
-	// start is 8 byte aligned, which may permit optimizations on 64-bit CPUs.
+	// Separate the buffers so LZ4 treats them as separate. Use 8 bytes to maintain 8 byte alignment,
+	// assuming malloc's result was aligned. This may permit optimizations on 64-bit CPUs.
 	const bufferSeparation = 8
 	mallocBuffer := C.malloc(2*hugeStreamingBlockSize + bufferSeparation)
 	buffer1 := mallocBuffer


### PR DESCRIPTION
Ensure we do not trigger the bug where the input buffers to
LZ4_compress_fast_continue are "accidentally" contiguous, so it
compresses blocks across them. This bug was fixed for Writer in
commit ca071684a5c2.

I do not believe CompressReader can trigger this bug because it will
only call LZ4_compress_fast_continue with a "partial" block < 64 kiB
once, at the end of the file. To trigger the problem, we need two
"partial" blocks, because then LZ4_compress_fast_continue will assume
it can use the last 64 kiB of data, which spans more than just the
last call. However, it seems worth explicitly separating these
buffers to make this impossible, in case the code is changed in the
future.

The benchmark results seem to be slightly faster after this change
on my laptop. If true, this must be from malloc/free/Cgo overhead.

Before (best run of 5 with -benchtime=30s):

```
goos: darwin
goarch: amd64
pkg: github.com/DataDog/golz4
cpu: Intel(R) Core(TM) i7-8569U CPU @ 2.80GHz
BenchmarkStreamCompressReader-8        43509      795162 ns/op  13186.95 MB/s      248 B/op        5 allocs/op
```

After (best run of 5)

```
BenchmarkStreamCompressReader-8        45981      772836 ns/op  13567.90 MB/s      248 B/op        5 allocs/op
```